### PR TITLE
feat: Add GET /api/contacts endpoint with pagination

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from backend.app.exceptions import (
     memoro_exception_handler,
 )
 from backend.app.logger import setup_logging
-from backend.app.routers import interactions
+from backend.app.routers import contacts, interactions
 
 # Setup logging
 setup_logging(log_level=settings.log_level, environment=settings.environment)
@@ -63,6 +63,7 @@ app.add_exception_handler(Exception, general_exception_handler)
 
 # Register routers
 app.include_router(interactions.router)
+app.include_router(contacts.router)
 
 
 @app.get("/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -104,6 +104,16 @@ class Contact(ContactBase):
     user_id: UUID
 
 
+class ContactListResponse(BaseModel):
+    """Paginated contact list response."""
+
+    contacts: list[Contact]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
 # Interaction Models
 
 

--- a/backend/app/routers/contacts.py
+++ b/backend/app/routers/contacts.py
@@ -1,0 +1,72 @@
+"""Contact endpoints."""
+
+import math
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Query, status
+
+from backend.app.db import get_db_connection, load_sql
+from backend.app.models import Contact, ContactListResponse
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/contacts", tags=["contacts"])
+
+# Load SQL queries
+SQL_LIST_CONTACTS = load_sql("contacts/list.sql")
+SQL_COUNT_CONTACTS = load_sql("contacts/count.sql")
+
+
+@router.get("", response_model=ContactListResponse, status_code=status.HTTP_200_OK)
+async def list_contacts(
+    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
+    page_size: int = Query(20, ge=1, le=100, description="Number of contacts per page"),
+    # TODO: Add user authentication and get user_id from session
+    user_id: UUID = UUID("00000000-0000-0000-0000-000000000000"),  # Placeholder
+) -> ContactListResponse:
+    """
+    List all contacts for the authenticated user with pagination.
+
+    Returns contacts sorted alphabetically by last name, then first name.
+    """
+    offset = (page - 1) * page_size
+
+    async with get_db_connection() as conn:
+        # Get total count
+        count_row = await conn.fetchrow(SQL_COUNT_CONTACTS, user_id)
+        total = count_row["total"]
+
+        # Get paginated contacts
+        rows = await conn.fetch(SQL_LIST_CONTACTS, user_id, page_size, offset)
+
+        contacts = [
+            Contact(
+                id=row["id"],
+                user_id=row["user_id"],
+                first_name=row["first_name"],
+                last_name=row["last_name"],
+                birthday=row["birthday"],
+                latest_news=row["latest_news"],
+            )
+            for row in rows
+        ]
+
+        total_pages = math.ceil(total / page_size) if total > 0 else 0
+
+        logger.info(
+            "contacts_listed",
+            user_id=str(user_id),
+            page=page,
+            page_size=page_size,
+            total=total,
+            returned=len(contacts),
+        )
+
+        return ContactListResponse(
+            contacts=contacts,
+            total=total,
+            page=page,
+            page_size=page_size,
+            total_pages=total_pages,
+        )

--- a/backend/app/sql/contacts/count.sql
+++ b/backend/app/sql/contacts/count.sql
@@ -1,0 +1,4 @@
+-- Count total contacts for a user
+SELECT COUNT(*) as total
+FROM contact
+WHERE user_id = $1;

--- a/backend/app/sql/contacts/list.sql
+++ b/backend/app/sql/contacts/list.sql
@@ -1,0 +1,14 @@
+-- List contacts for a user with pagination
+SELECT
+    id,
+    first_name,
+    last_name,
+    birthday,
+    latest_news,
+    created_at,
+    updated_at
+FROM contact
+WHERE user_id = $1
+ORDER BY last_name ASC, first_name ASC
+LIMIT $2
+OFFSET $3;

--- a/backend/tests/test_contacts.py
+++ b/backend/tests/test_contacts.py
@@ -1,0 +1,158 @@
+"""Tests for contact endpoints."""
+
+from datetime import date
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestListContacts:
+    """Tests for GET /api/contacts endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_list_contacts_success(self, client: AsyncClient):
+        """Test successful contact list retrieval."""
+
+        def make_record(**kwargs):
+            class MockRecord(dict):
+                def __getitem__(self, key):
+                    return super().__getitem__(key)
+
+            return MockRecord(**kwargs)
+
+        mock_conn = patch("backend.app.routers.contacts.get_db_connection")
+
+        with mock_conn as mock:
+            mock_instance = mock.return_value.__aenter__.return_value
+
+            # Mock count query
+            mock_instance.fetchrow.return_value = make_record(total=2)
+
+            # Mock list query
+            mock_instance.fetch.return_value = [
+                make_record(
+                    id=uuid4(),
+                    user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                    first_name="Alice",
+                    last_name="Anderson",
+                    birthday=date(1990, 1, 1),
+                    latest_news="Recent update about Alice",
+                ),
+                make_record(
+                    id=uuid4(),
+                    user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                    first_name="Bob",
+                    last_name="Brown",
+                    birthday=None,
+                    latest_news="Recent update about Bob",
+                ),
+            ]
+
+            response = await client.get("/api/contacts")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify pagination metadata
+        assert data["total"] == 2
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+        assert data["total_pages"] == 1
+
+        # Verify contacts
+        assert len(data["contacts"]) == 2
+        assert data["contacts"][0]["first_name"] == "Alice"
+        assert data["contacts"][1]["first_name"] == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_list_contacts_empty(self, client: AsyncClient):
+        """Test contact list when no contacts exist."""
+
+        def make_record(**kwargs):
+            class MockRecord(dict):
+                def __getitem__(self, key):
+                    return super().__getitem__(key)
+
+            return MockRecord(**kwargs)
+
+        mock_conn = patch("backend.app.routers.contacts.get_db_connection")
+
+        with mock_conn as mock:
+            mock_instance = mock.return_value.__aenter__.return_value
+
+            # Mock count query
+            mock_instance.fetchrow.return_value = make_record(total=0)
+
+            # Mock list query
+            mock_instance.fetch.return_value = []
+
+            response = await client.get("/api/contacts")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total"] == 0
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+        assert data["total_pages"] == 0
+        assert len(data["contacts"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_list_contacts_pagination(self, client: AsyncClient):
+        """Test contact list pagination parameters."""
+
+        def make_record(**kwargs):
+            class MockRecord(dict):
+                def __getitem__(self, key):
+                    return super().__getitem__(key)
+
+            return MockRecord(**kwargs)
+
+        mock_conn = patch("backend.app.routers.contacts.get_db_connection")
+
+        with mock_conn as mock:
+            mock_instance = mock.return_value.__aenter__.return_value
+
+            # Mock count query (50 total contacts)
+            mock_instance.fetchrow.return_value = make_record(total=50)
+
+            # Mock list query (return 10 contacts for page 2)
+            mock_instance.fetch.return_value = [
+                make_record(
+                    id=uuid4(),
+                    user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                    first_name=f"User{i}",
+                    last_name=f"Name{i}",
+                    birthday=None,
+                    latest_news=None,
+                )
+                for i in range(10, 20)
+            ]
+
+            response = await client.get("/api/contacts?page=2&page_size=10")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total"] == 50
+        assert data["page"] == 2
+        assert data["page_size"] == 10
+        assert data["total_pages"] == 5
+        assert len(data["contacts"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_list_contacts_invalid_page(self, client: AsyncClient):
+        """Test contact list with invalid page parameter."""
+        response = await client.get("/api/contacts?page=0")
+        assert response.status_code == 422  # Validation error
+
+    @pytest.mark.asyncio
+    async def test_list_contacts_invalid_page_size(self, client: AsyncClient):
+        """Test contact list with invalid page_size parameter."""
+        response = await client.get("/api/contacts?page_size=101")
+        assert response.status_code == 422  # Validation error (max 100)
+
+        response = await client.get("/api/contacts?page_size=0")
+        assert response.status_code == 422  # Validation error (min 1)


### PR DESCRIPTION
## Summary
Implements the GET /api/contacts endpoint to list all contacts for a user with pagination support.

## Changes
- ✅ SQL queries for listing and counting contacts
- ✅ Contacts router with list endpoint
- ✅ Pagination with configurable page size (1-100)
- ✅ Alphabetical sorting (last name, then first name)
- ✅ ContactListResponse model with metadata
- ✅ 5 comprehensive test cases
- ✅ Router registered in main.py

## Features
- Query parameters: `page` (default 1), `page_size` (default 20, max 100)
- Returns: contacts array + pagination metadata (total, page, page_size, total_pages)
- Validation for invalid parameters
- Handles empty contact lists
- Uses `get_db_connection()` for clean read-only operations

## Testing
All 13 tests passing:
- 8 interaction tests (existing)
- 5 new contact tests:
  - ✅ Successful list retrieval
  - ✅ Empty list handling
  - ✅ Pagination parameters
  - ✅ Invalid page validation
  - ✅ Invalid page_size validation

## Example Usage
\`\`\`bash
# Default pagination (page 1, 20 items)
GET /api/contacts

# Custom pagination
GET /api/contacts?page=2&page_size=50
\`\`\`

## Response Format
\`\`\`json
{
  "contacts": [
    {
      "id": "uuid",
      "user_id": "uuid",
      "first_name": "Alice",
      "last_name": "Anderson",
      "birthday": "1990-01-01",
      "latest_news": "Recent update"
    }
  ],
  "total": 50,
  "page": 1,
  "page_size": 20,
  "total_pages": 3
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)