### PR TITLE
Add GET /api/interactions/{id} endpoint

### DIFF
--- a/backend/app/sql/interactions/get_by_id.sql
+++ b/backend/app/sql/interactions/get_by_id.sql
@@ -1,0 +1,12 @@
+-- Get a single interaction by ID
+SELECT
+    id,
+    user_id,
+    contact_id,
+    interaction_date,
+    notes,
+    location,
+    created_at,
+    updated_at
+FROM interaction
+WHERE id = $1 AND user_id = $2;


### PR DESCRIPTION
## Summary
- Implemented GET /api/interactions/{id} - retrieve single interaction by ID

## Implementation Details

### Endpoint
**GET /api/interactions/{id}**: Returns interaction details with 404 if not found or doesn't belong to user

### SQL Query
- `interactions/get_by_id.sql` - Fetch interaction by ID with user_id validation

### Testing
3 new test cases in TestGetInteraction:
- **success**: Successfully retrieve interaction with all fields
- **not found**: Returns 404 when interaction doesn't exist
- **invalid UUID**: Returns 422 for malformed UUID

All 11 interaction tests passing (8 existing + 3 new).

### Code Quality
- Clean endpoint implementation using global exception handlers
- Consistent with existing CRUD patterns
- Structured logging for retrieval operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)