### PR TITLE
Add POST /api/search endpoint with fuzzy and term search

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from backend.app.exceptions import (
     memoro_exception_handler,
 )
 from backend.app.logger import setup_logging
-from backend.app.routers import contacts, interactions
+from backend.app.routers import contacts, interactions, search
 
 # Setup logging
 setup_logging(log_level=settings.log_level, environment=settings.environment)
@@ -64,6 +64,7 @@ app.add_exception_handler(Exception, general_exception_handler)
 # Register routers
 app.include_router(interactions.router)
 app.include_router(contacts.router)
+app.include_router(search.router)
 
 
 @app.get("/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -185,3 +185,58 @@ class ContactSummary(BaseModel):
     recent_interactions: list[Interaction]
     family_members: list[FamilyMemberWithDetails]
     last_interaction_date: date | None
+
+
+# Search Models
+
+
+class SearchRequest(BaseModel):
+    """Request model for unified search."""
+
+    query: str = Field(..., min_length=1, description="Search query string")
+    search_type: str = Field(
+        "semantic",
+        description="Search type: 'semantic', 'fuzzy', or 'term'",
+        pattern="^(semantic|fuzzy|term)$",
+    )
+    limit: int = Field(10, ge=1, le=100, description="Maximum number of results to return")
+
+
+class SearchResultContact(BaseModel):
+    """Contact information in search results."""
+
+    id: UUID
+    first_name: str
+    last_name: str
+    birthday: date | None
+    latest_news: str | None
+
+
+class SearchResultInteraction(BaseModel):
+    """Interaction information in search results."""
+
+    id: UUID
+    contact_id: UUID
+    interaction_date: date
+    notes: str
+    location: str | None
+    contact_first_name: str
+    contact_last_name: str
+
+
+class SearchResult(BaseModel):
+    """Unified search result."""
+
+    result_type: str = Field(..., description="Type of result: 'contact' or 'interaction'")
+    contact: SearchResultContact | None = None
+    interaction: SearchResultInteraction | None = None
+    score: float = Field(..., ge=0.0, le=1.0, description="Relevance score")
+
+
+class SearchResponse(BaseModel):
+    """Search results response."""
+
+    results: list[SearchResult]
+    query: str
+    search_type: str
+    total_results: int

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,0 +1,161 @@
+"""Search endpoints."""
+
+from uuid import UUID
+
+import asyncpg
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from backend.app.db import get_db_dependency, load_sql
+from backend.app.models import (
+    SearchRequest,
+    SearchResponse,
+    SearchResult,
+    SearchResultContact,
+    SearchResultInteraction,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/search", tags=["search"])
+
+# Load SQL queries
+SQL_FUZZY_CONTACTS = load_sql("search/fuzzy_contacts.sql")
+SQL_FUZZY_INTERACTIONS = load_sql("search/fuzzy_interactions.sql")
+SQL_TERM_CONTACTS = load_sql("search/term_contacts.sql")
+SQL_TERM_INTERACTIONS = load_sql("search/term_interactions.sql")
+SQL_SEMANTIC_INTERACTIONS = load_sql("search/semantic_interactions.sql")
+
+
+@router.post("", response_model=SearchResponse, status_code=status.HTTP_200_OK)
+async def search(
+    search_request: SearchRequest,
+    # TODO: Add user authentication and get user_id from session
+    user_id: UUID = UUID("00000000-0000-0000-0000-000000000000"),  # Placeholder
+    conn: asyncpg.Connection = Depends(get_db_dependency),
+) -> SearchResponse:
+    """
+    Unified search endpoint for contacts and interactions.
+
+    Supports three search types:
+    - semantic: Vector similarity search on interaction embeddings
+    - fuzzy: Trigram similarity matching on text fields
+    - term: Basic ILIKE pattern matching
+
+    Returns combined results from contacts and interactions, sorted by relevance.
+    """
+    results = []
+
+    if search_request.search_type == "semantic":
+        # Semantic search only works on interactions with embeddings
+        # For now, we'll need an embedding service to generate query embedding
+        # TODO: Integrate with embedding service
+        raise HTTPException(
+            status_code=501,
+            detail="Semantic search not yet implemented - requires embedding service integration",
+        )
+
+    elif search_request.search_type == "fuzzy":
+        # Fuzzy search on contacts
+        contact_rows = await conn.fetch(
+            SQL_FUZZY_CONTACTS, user_id, search_request.query, search_request.limit
+        )
+
+        for row in contact_rows:
+            results.append(
+                SearchResult(
+                    result_type="contact",
+                    contact=SearchResultContact(
+                        id=row["id"],
+                        first_name=row["first_name"],
+                        last_name=row["last_name"],
+                        birthday=row["birthday"],
+                        latest_news=row["latest_news"],
+                    ),
+                    score=float(row["score"]),
+                )
+            )
+
+        # Fuzzy search on interactions
+        interaction_rows = await conn.fetch(
+            SQL_FUZZY_INTERACTIONS, user_id, search_request.query, search_request.limit
+        )
+
+        for row in interaction_rows:
+            results.append(
+                SearchResult(
+                    result_type="interaction",
+                    interaction=SearchResultInteraction(
+                        id=row["id"],
+                        contact_id=row["contact_id"],
+                        interaction_date=row["interaction_date"],
+                        notes=row["notes"],
+                        location=row["location"],
+                        contact_first_name=row["contact_first_name"],
+                        contact_last_name=row["contact_last_name"],
+                    ),
+                    score=float(row["score"]),
+                )
+            )
+
+    elif search_request.search_type == "term":
+        # Term search on contacts
+        contact_rows = await conn.fetch(
+            SQL_TERM_CONTACTS, user_id, search_request.query, search_request.limit
+        )
+
+        for row in contact_rows:
+            results.append(
+                SearchResult(
+                    result_type="contact",
+                    contact=SearchResultContact(
+                        id=row["id"],
+                        first_name=row["first_name"],
+                        last_name=row["last_name"],
+                        birthday=row["birthday"],
+                        latest_news=row["latest_news"],
+                    ),
+                    score=float(row["score"]),
+                )
+            )
+
+        # Term search on interactions
+        interaction_rows = await conn.fetch(
+            SQL_TERM_INTERACTIONS, user_id, search_request.query, search_request.limit
+        )
+
+        for row in interaction_rows:
+            results.append(
+                SearchResult(
+                    result_type="interaction",
+                    interaction=SearchResultInteraction(
+                        id=row["id"],
+                        contact_id=row["contact_id"],
+                        interaction_date=row["interaction_date"],
+                        notes=row["notes"],
+                        location=row["location"],
+                        contact_first_name=row["contact_first_name"],
+                        contact_last_name=row["contact_last_name"],
+                    ),
+                    score=float(row["score"]),
+                )
+            )
+
+    # Sort all results by score (descending) and limit to requested amount
+    results.sort(key=lambda r: r.score, reverse=True)
+    results = results[: search_request.limit]
+
+    logger.info(
+        "search_completed",
+        user_id=str(user_id),
+        query=search_request.query,
+        search_type=search_request.search_type,
+        total_results=len(results),
+    )
+
+    return SearchResponse(
+        results=results,
+        query=search_request.query,
+        search_type=search_request.search_type,
+        total_results=len(results),
+    )

--- a/backend/app/sql/search/fuzzy_contacts.sql
+++ b/backend/app/sql/search/fuzzy_contacts.sql
@@ -1,0 +1,13 @@
+-- Fuzzy search contacts by name
+SELECT
+    id,
+    first_name,
+    last_name,
+    birthday,
+    latest_news,
+    SIMILARITY(first_name || ' ' || last_name, $2) as score
+FROM contact
+WHERE user_id = $1
+    AND (first_name % $2 OR last_name % $2 OR (first_name || ' ' || last_name) % $2)
+ORDER BY score DESC
+LIMIT $3;

--- a/backend/app/sql/search/fuzzy_interactions.sql
+++ b/backend/app/sql/search/fuzzy_interactions.sql
@@ -1,0 +1,19 @@
+-- Fuzzy search interactions by notes or location
+SELECT
+    i.id,
+    i.contact_id,
+    i.interaction_date,
+    i.notes,
+    i.location,
+    c.first_name as contact_first_name,
+    c.last_name as contact_last_name,
+    GREATEST(
+        SIMILARITY(i.notes, $2),
+        COALESCE(SIMILARITY(i.location, $2), 0)
+    ) as score
+FROM interaction i
+JOIN contact c ON i.contact_id = c.id
+WHERE i.user_id = $1
+    AND (i.notes % $2 OR i.location % $2)
+ORDER BY score DESC
+LIMIT $3;

--- a/backend/app/sql/search/semantic_interactions.sql
+++ b/backend/app/sql/search/semantic_interactions.sql
@@ -1,0 +1,16 @@
+-- Semantic search interactions using pgvector cosine similarity
+SELECT
+    i.id,
+    i.contact_id,
+    i.interaction_date,
+    i.notes,
+    i.location,
+    c.first_name as contact_first_name,
+    c.last_name as contact_last_name,
+    1 - (i.embedding <=> $2::vector) as score
+FROM interaction i
+JOIN contact c ON i.contact_id = c.id
+WHERE i.user_id = $1
+    AND i.embedding IS NOT NULL
+ORDER BY i.embedding <=> $2::vector
+LIMIT $3;

--- a/backend/app/sql/search/term_contacts.sql
+++ b/backend/app/sql/search/term_contacts.sql
@@ -1,0 +1,17 @@
+-- Term-based search contacts (ILIKE matching)
+SELECT
+    id,
+    first_name,
+    last_name,
+    birthday,
+    latest_news,
+    1.0 as score  -- Term search doesn't provide relevance score
+FROM contact
+WHERE user_id = $1
+    AND (
+        first_name ILIKE '%' || $2 || '%'
+        OR last_name ILIKE '%' || $2 || '%'
+        OR latest_news ILIKE '%' || $2 || '%'
+    )
+ORDER BY first_name, last_name
+LIMIT $3;

--- a/backend/app/sql/search/term_interactions.sql
+++ b/backend/app/sql/search/term_interactions.sql
@@ -1,0 +1,19 @@
+-- Term-based search interactions (ILIKE matching)
+SELECT
+    i.id,
+    i.contact_id,
+    i.interaction_date,
+    i.notes,
+    i.location,
+    c.first_name as contact_first_name,
+    c.last_name as contact_last_name,
+    1.0 as score  -- Term search doesn't provide relevance score
+FROM interaction i
+JOIN contact c ON i.contact_id = c.id
+WHERE i.user_id = $1
+    AND (
+        i.notes ILIKE '%' || $2 || '%'
+        OR i.location ILIKE '%' || $2 || '%'
+    )
+ORDER BY i.interaction_date DESC
+LIMIT $3;

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,355 @@
+"""Tests for search endpoints."""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestSearch:
+    """Tests for POST /api/search endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_search_fuzzy_contacts(self, client: AsyncClient, mock_db_connection):
+        """Test fuzzy search for contacts."""
+
+        contact_id = uuid4()
+
+        # Mock fuzzy search on contacts
+        mock_db_connection.fetch.side_effect = [
+            # Contact results
+            [
+                mock_db_connection.make_record(
+                    id=contact_id,
+                    first_name="Alice",
+                    last_name="Anderson",
+                    birthday=date(1990, 1, 1),
+                    latest_news="Recent update",
+                    score=0.85,
+                ),
+            ],
+            # Interaction results (empty)
+            [],
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "alice", "search_type": "fuzzy", "limit": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["query"] == "alice"
+        assert data["search_type"] == "fuzzy"
+        assert data["total_results"] == 1
+        assert len(data["results"]) == 1
+        assert data["results"][0]["result_type"] == "contact"
+        assert data["results"][0]["contact"]["first_name"] == "Alice"
+        assert data["results"][0]["score"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_search_fuzzy_interactions(self, client: AsyncClient, mock_db_connection):
+        """Test fuzzy search for interactions."""
+
+        interaction_id = uuid4()
+        contact_id = uuid4()
+
+        # Mock fuzzy search
+        mock_db_connection.fetch.side_effect = [
+            # Contact results (empty)
+            [],
+            # Interaction results
+            [
+                mock_db_connection.make_record(
+                    id=interaction_id,
+                    contact_id=contact_id,
+                    interaction_date=date(2024, 1, 15),
+                    notes="Had coffee at Starbucks",
+                    location="Starbucks",
+                    contact_first_name="Bob",
+                    contact_last_name="Brown",
+                    score=0.75,
+                ),
+            ],
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "coffee", "search_type": "fuzzy", "limit": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_results"] == 1
+        assert data["results"][0]["result_type"] == "interaction"
+        assert data["results"][0]["interaction"]["notes"] == "Had coffee at Starbucks"
+        assert data["results"][0]["score"] == 0.75
+
+    @pytest.mark.asyncio
+    async def test_search_term_contacts(self, client: AsyncClient, mock_db_connection):
+        """Test term search for contacts."""
+
+        contact_id = uuid4()
+
+        # Mock term search
+        mock_db_connection.fetch.side_effect = [
+            # Contact results
+            [
+                mock_db_connection.make_record(
+                    id=contact_id,
+                    first_name="Charlie",
+                    last_name="Chen",
+                    birthday=None,
+                    latest_news="Working at Google",
+                    score=1.0,
+                ),
+            ],
+            # Interaction results (empty)
+            [],
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "google", "search_type": "term", "limit": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["search_type"] == "term"
+        assert data["total_results"] == 1
+        assert data["results"][0]["contact"]["latest_news"] == "Working at Google"
+        assert data["results"][0]["score"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_search_term_interactions(self, client: AsyncClient, mock_db_connection):
+        """Test term search for interactions."""
+
+        interaction_id = uuid4()
+        contact_id = uuid4()
+
+        # Mock term search
+        mock_db_connection.fetch.side_effect = [
+            # Contact results (empty)
+            [],
+            # Interaction results
+            [
+                mock_db_connection.make_record(
+                    id=interaction_id,
+                    contact_id=contact_id,
+                    interaction_date=date(2024, 1, 10),
+                    notes="Discussed Python project",
+                    location="Office",
+                    contact_first_name="Diana",
+                    contact_last_name="Davis",
+                    score=1.0,
+                ),
+            ],
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "python", "search_type": "term", "limit": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_results"] == 1
+        assert data["results"][0]["interaction"]["notes"] == "Discussed Python project"
+
+    @pytest.mark.asyncio
+    async def test_search_combined_results(self, client: AsyncClient, mock_db_connection):
+        """Test search returning both contacts and interactions."""
+
+        contact_id = uuid4()
+        interaction_id = uuid4()
+
+        # Mock fuzzy search with both types
+        mock_db_connection.fetch.side_effect = [
+            # Contact results
+            [
+                mock_db_connection.make_record(
+                    id=contact_id,
+                    first_name="Eve",
+                    last_name="Evans",
+                    birthday=None,
+                    latest_news="Loves basketball",
+                    score=0.90,
+                ),
+            ],
+            # Interaction results
+            [
+                mock_db_connection.make_record(
+                    id=interaction_id,
+                    contact_id=contact_id,
+                    interaction_date=date(2024, 1, 5),
+                    notes="Played basketball together",
+                    location="Park",
+                    contact_first_name="Eve",
+                    contact_last_name="Evans",
+                    score=0.88,
+                ),
+            ],
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "basketball", "search_type": "fuzzy", "limit": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_results"] == 2
+        # Results should be sorted by score (0.90, 0.88)
+        assert data["results"][0]["result_type"] == "contact"
+        assert data["results"][0]["score"] == 0.90
+        assert data["results"][1]["result_type"] == "interaction"
+        assert data["results"][1]["score"] == 0.88
+
+    @pytest.mark.asyncio
+    async def test_search_empty_results(self, client: AsyncClient, mock_db_connection):
+        """Test search with no results."""
+
+        # Mock empty results
+        mock_db_connection.fetch.side_effect = [
+            [],  # Contact results
+            [],  # Interaction results
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "nonexistent", "search_type": "fuzzy", "limit": 10},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_results"] == 0
+        assert len(data["results"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_limit_applied(self, client: AsyncClient, mock_db_connection):
+        """Test that search limit is properly applied."""
+
+        # Mock many results
+        mock_db_connection.fetch.side_effect = [
+            # 5 contact results
+            [
+                mock_db_connection.make_record(
+                    id=uuid4(),
+                    first_name=f"User{i}",
+                    last_name=f"Name{i}",
+                    birthday=None,
+                    latest_news=None,
+                    score=0.9 - (i * 0.1),
+                )
+                for i in range(5)
+            ],
+            # 5 interaction results
+            [
+                mock_db_connection.make_record(
+                    id=uuid4(),
+                    contact_id=uuid4(),
+                    interaction_date=date(2024, 1, i + 1),
+                    notes=f"Note {i}",
+                    location=None,
+                    contact_first_name="Test",
+                    contact_last_name="User",
+                    score=0.8 - (i * 0.1),
+                )
+                for i in range(5)
+            ],
+        ]
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "test", "search_type": "fuzzy", "limit": 3},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should only return 3 results (top scored)
+        assert data["total_results"] == 3
+        assert len(data["results"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_search_type(self, client: AsyncClient, mock_db_connection):
+        """Test search with invalid search type."""
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "test", "search_type": "invalid", "limit": 10},
+        )
+
+        assert response.status_code == 422  # Validation error
+
+    @pytest.mark.asyncio
+    async def test_search_missing_query(self, client: AsyncClient, mock_db_connection):
+        """Test search with missing query."""
+
+        response = await client.post(
+            "/api/search",
+            json={"search_type": "fuzzy", "limit": 10},
+        )
+
+        assert response.status_code == 422  # Validation error
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query(self, client: AsyncClient, mock_db_connection):
+        """Test search with empty query."""
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "", "search_type": "fuzzy", "limit": 10},
+        )
+
+        assert response.status_code == 422  # Validation error (min_length=1)
+
+    @pytest.mark.asyncio
+    async def test_search_default_search_type(self, client: AsyncClient, mock_db_connection):
+        """Test search with default search type (semantic)."""
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "test", "limit": 10},
+        )
+
+        # Semantic search not yet implemented
+        assert response.status_code == 501
+        assert "not yet implemented" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_search_semantic_not_implemented(self, client: AsyncClient, mock_db_connection):
+        """Test that semantic search returns 501."""
+
+        response = await client.post(
+            "/api/search",
+            json={"query": "test", "search_type": "semantic", "limit": 10},
+        )
+
+        assert response.status_code == 501
+        assert "Semantic search not yet implemented" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_search_limit_validation(self, client: AsyncClient, mock_db_connection):
+        """Test search limit validation."""
+
+        # Limit too large
+        response = await client.post(
+            "/api/search",
+            json={"query": "test", "search_type": "fuzzy", "limit": 101},
+        )
+        assert response.status_code == 422
+
+        # Limit too small
+        response = await client.post(
+            "/api/search",
+            json={"query": "test", "search_type": "fuzzy", "limit": 0},
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Implements unified search endpoint for contacts and interactions
- Supports fuzzy search (trigram similarity) and term search (ILIKE matching)
- Semantic search placeholder (returns 501 - requires embedding service)
- Created 5 SQL queries leveraging PostgreSQL pg_trgm extension
- Returns combined, sorted results with relevance scores

## Implementation Details
- **Fuzzy search**: Uses pg_trgm SIMILARITY and % operator for approximate matching
- **Term search**: Uses ILIKE for exact substring matching
- **Result combination**: Merges contact and interaction results, sorts by score
- **Validation**: Enforces search_type pattern, query min length, limit range

## Test plan
- [x] All 54 tests pass
- [x] 13 new tests for search endpoint cover:
  - Fuzzy search on contacts and interactions
  - Term search on contacts and interactions
  - Combined results from both types
  - Empty results handling
  - Limit validation and application
  - Invalid/missing parameters (422)
  - Semantic search not implemented (501)

🤖 Generated with [Claude Code](https://claude.com/claude-code)